### PR TITLE
Write training histories from SMAC exploration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Custom additions to gitignore
 datasets/sdo_128/bin
 *~
+training/version0/argument-search-results/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -13,10 +13,8 @@ You are responsible for managing your own version of Python on the servers. Thes
 
 > wget https://repo.continuum.io/archive/Anaconda2-4.4.0-Linux-x86_64.sh; chmod a+x Anaconda2-4.4.0-Linux-x86_64.sh; ./Anaconda2-4.4.0-Linux-x86_64.sh
 
-> conda update --all
-> conda install -c anaconda tensorflow-gpu=1.1.0
-> conda install astropy
-> conda install pydot
-> conda install graphviz
+> conda update --all  
+> conda install astropy pydot graphviz  
+> pip install tensorflow tensorflow-gpu  
 
 Please update this based on your own experience.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You are responsible for managing your own version of Python on the servers. Thes
 > wget https://repo.continuum.io/archive/Anaconda2-4.4.0-Linux-x86_64.sh; chmod a+x Anaconda2-4.4.0-Linux-x86_64.sh; ./Anaconda2-4.4.0-Linux-x86_64.sh
 
 > conda update --all  
-> conda install astropy pydot graphviz  
+> conda install astropy pydot graphviz keras  
 > pip install tensorflow tensorflow-gpu  
 
 Please update this based on your own experience.

--- a/training/version0/architectures.py
+++ b/training/version0/architectures.py
@@ -49,6 +49,7 @@ import numpy as np
 
 # Deep learning training library
 from keras.callbacks import TensorBoard
+from corona_callbacks import CoronaCallbacks
 
 # Utilities for this script
 import os
@@ -132,7 +133,7 @@ input_height = 4096
 maximum_y_value = 0.00054361000000000004
 y_reweight = 1839.55409209 # Scale maximum value to 1
 input_image = Input(shape=(input_width, input_height, input_channels))
-validation_steps = 20
+validation_steps = 30
 x = input_image
 
 #####################################
@@ -235,12 +236,15 @@ print "loading image dataset"
 #   Optimizing the Neural Network   #
 #####################################
 
+tensorboard_callbacks = TensorBoard(log_dir=tensorboard_log_data_path)
+corona_callbacks = CoronaCallbacks("argument-search-results", args)
+
 history = forecaster.fit_generator(generator(),
-                                   100,  #  steps per epoch
-                                   epochs=100,
+                                   200,  #  steps per epoch
+                                   epochs=200,
                                    validation_data=validation_generator(),
                                    validation_steps=validation_steps,
-                                   callbacks=[TensorBoard(log_dir=tensorboard_log_data_path)])
+                                   callbacks=[tensorboard_callbacks, corona_callbacks])
 
 # Loss on the training set
 print history.history['loss']

--- a/training/version0/architectures.py
+++ b/training/version0/architectures.py
@@ -240,8 +240,8 @@ tensorboard_callbacks = TensorBoard(log_dir=tensorboard_log_data_path)
 corona_callbacks = CoronaCallbacks("argument-search-results", args)
 
 history = forecaster.fit_generator(generator(),
-                                   200,  #  steps per epoch
-                                   epochs=200,
+                                   50,  #  steps per epoch
+                                   epochs=300,
                                    validation_data=validation_generator(),
                                    validation_steps=validation_steps,
                                    callbacks=[tensorboard_callbacks, corona_callbacks])

--- a/training/version0/cleanup.sh
+++ b/training/version0/cleanup.sh
@@ -1,0 +1,4 @@
+rm -r /tmp/version0
+rm argument-search-results/*
+touch argument-search-results/.gitkeep
+rm -r smac-output*

--- a/training/version0/corona_callbacks.py
+++ b/training/version0/corona_callbacks.py
@@ -45,6 +45,7 @@ def arguments_to_filename(args):
     Take the arguments object from argparse and turn it into a filename.
     """
     arg_dict = args.__dict__
+    arg_dict.pop("ignore", None)
     l = list(arg_dict)
     l = sorted(l)
     filename = "search"
@@ -59,6 +60,7 @@ def arguments_to_csv_header(args):
     """
     header = "validation loss, training loss"
     arg_dict = args.__dict__
+    arg_dict.pop("ignore", None)
     l = list(arg_dict)
     l = sorted(l)
     for arg in l:
@@ -73,6 +75,7 @@ def arguments_to_csv_row(args):
     """
     row = ""
     arg_dict = args.__dict__
+    arg_dict.pop("ignore", None)
     l = list(arg_dict)
     l = sorted(l)
     for arg in l:

--- a/training/version0/corona_callbacks.py
+++ b/training/version0/corona_callbacks.py
@@ -1,0 +1,80 @@
+import keras
+import time
+
+class CoronaCallbacks(keras.callbacks.Callback):
+
+    def __init__(self, filepath, network_arguments):
+        timestr = time.strftime("%Y%m%d-%H%M%S")
+        self.filepath = filepath + "/" + timestr
+        self.argument_string = arguments_to_csv_row(network_arguments)
+        with open(self.filepath, "wb") as out:
+            csv_header_string =  arguments_to_csv_header(network_arguments)
+            out.write(csv_header_string)
+            out.write("\n")
+        
+    def on_train_begin(self, logs={}):
+        self.losses = []
+        return
+
+    def on_train_end(self, logs={}):
+        
+        with open(self.filepath, "ab") as out:
+            for loss in self.losses:
+                out.write(str(loss[0]))
+                out.write(",")
+                out.write(str(loss[1]))
+                out.write(self.argument_string)
+                out.write("\n")
+        return
+
+    def on_epoch_begin(self, epoch, logs={}):
+        return
+
+    def on_epoch_end(self, epoch, logs={}):
+        self.losses.append([logs.get('val_loss'), logs.get('loss')])
+        return
+
+    def on_batch_begin(self, batch, logs={}):
+        return
+
+    def on_batch_end(self, batch, logs={}):
+        return
+
+def arguments_to_filename(args):
+    """
+    Take the arguments object from argparse and turn it into a filename.
+    """
+    arg_dict = args.__dict__
+    l = list(arg_dict)
+    l = sorted(l)
+    filename = "search"
+    for arg in l:
+        filename += "--" + arg + "-" + str(arg_dict[arg])
+    return filename + ".csv"
+
+def arguments_to_csv_header(args):
+    """
+    Take the arguments from argparse and produce a string for the header value.
+    This will have the form "epoch number,training score,test score,layer1 parameter1,..."
+    """
+    header = "validation loss, training loss"
+    arg_dict = args.__dict__
+    l = list(arg_dict)
+    l = sorted(l)
+    for arg in l:
+        header += "," + arg
+    return header
+    
+def arguments_to_csv_row(args):
+    """
+    Take the arguments from the argparse object and turn it into the string
+    that will be added to every row. This is useful since it will be easier
+    to load into analytical programming environments like R.
+    """
+    row = ""
+    arg_dict = args.__dict__
+    l = list(arg_dict)
+    l = sorted(l)
+    for arg in l:
+        row += str(arg_dict[arg]) + ","
+    return row

--- a/training/version0/smac.sh
+++ b/training/version0/smac.sh
@@ -1,1 +1,1 @@
-../smac-v2.10.03-master-778/smac --use-instances false --numberOfRunsLimit 10 --pcs-file ../version0/parameters_v1.pcs --algo "python architectures.py" --run-objective QUALITY
+../smac-v2.10.03-master-778/smac --use-instances false --numberOfRunsLimit 100 --pcs-file ../version0/parameters_v1.pcs --algo "python architectures.py" --run-objective QUALITY


### PR DESCRIPTION
This pull request adds custom callbacks that will track the training and validation set performance through time, and write the output to a datetime named file at the completion of training. You can view these performance histories and the parameters producing them in the `training/version0/argument-search-results/` folder. 