### PR TITLE
Saliency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ datasets/sdo_128/bin
 *~
 training/version0/argument-search-results/*
 training/version1/argument-search-results/*
+trained_models/
+smac-v2.10.03-master-778/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/network_models/xray_flux_forecast/fdl4/network.py
+++ b/network_models/xray_flux_forecast/fdl4/network.py
@@ -31,7 +31,7 @@ will be used.
 Before running the script, we recommend you start the tensorboard server so you
 can track the progress.
 
-`tensorboard --logdir=/tmp/version1`
+`tensorboard --logdir=/tmp/version4`
 
 """
 

--- a/science/attention.py
+++ b/science/attention.py
@@ -1,0 +1,59 @@
+import argparse
+from dataset_models.sdo.aia import aia
+import numpy as np
+from keras import backend as K
+from scipy.misc import imsave
+
+print "WARNING: This script is incomplete and currently assumes"
+print "you will use the AIA dataset model. Please update appropriately."
+print "Potential updates include the image count and the side channel selection."
+
+# Parse the command line arguments. You can view these from the command line
+# by issuing `python evaluate_network.py -h`
+parser = argparse.ArgumentParser(description='Evaluate a network on data')
+parser.add_argument('network_model', metavar='N', type=str, nargs=1,
+                    help='the full path to the network model that we want to evaluate. This will be a file with the .hdf5 extension.')
+args = parser.parse_args()
+
+# Specify the data
+#dataset_model = aia.AIA(side_channels=["hand_tailored"], aia_image_count=1, dependent_variable="flux delta")
+dataset_model = aia.AIA(side_channels=[""], aia_image_count=1, dependent_variable="flux delta")
+network_model = dataset_model.get_network_model(args.network_model[0])
+
+def compile_saliency_function(model):
+    """
+    Compiles a function to compute the saliency maps and predicted classes
+    for a given minibatch of input images.
+    """
+    inp1 = model.layers[0].input
+    #inp2 = model.get_layer("Side_Channel").input
+    output = model.layers[-1].output
+    loss = output[0]
+    grads = K.gradients(loss, inp1)[0]
+    grads /= (K.sqrt(K.mean(K.square(grads))) + 1e-5)
+    iterate = K.function([inp1, K.learning_phase()], [loss, grads])
+    return iterate
+
+saliency_function =  compile_saliency_function(network_model)
+
+dataset = dataset_model.get_validation_data()
+x_inputs = dataset[0]
+single_point =  x_inputs[0][0].reshape(1, 1024, 1024, 8)
+
+loss_value, grads_value = saliency_function([single_point, 0])
+
+layer = grads_value.reshape(1,8,1024,1024)[0][0]
+most = float("-Inf")
+least = float("Inf")
+print layer.shape
+for idx in range(0, 1024):
+    for idx2 in range(0, 1024):
+        most = max(layer[idx][idx2], most)
+        least = min(layer[idx][idx2], least)
+most = float(most)
+least = float(least)
+for idx in range(0, 1024):
+    for idx2 in range(0, 1024):
+        layer[idx][idx2] = 255.0 * (layer[idx][idx2] - least)/(most - least)
+
+imsave('gradient.png', layer)

--- a/science/attention.py
+++ b/science/attention.py
@@ -1,8 +1,15 @@
+"""
+The purpose of this script is to uncover what the network is paying attention to in the image.
+This is accomplished by examining the gradients of the loss function with respect to the
+inputs. Basically, the script asks, "how much will the loss function change if the input
+value changes".
+"""
 import argparse
 from dataset_models.sdo.aia import aia
 import numpy as np
 from keras import backend as K
 from scipy.misc import imsave
+from keras.layers import Input
 
 print "WARNING: This script is incomplete and currently assumes"
 print "you will use the AIA dataset model. Please update appropriately."
@@ -10,50 +17,89 @@ print "Potential updates include the image count and the side channel selection.
 
 # Parse the command line arguments. You can view these from the command line
 # by issuing `python evaluate_network.py -h`
-parser = argparse.ArgumentParser(description='Evaluate a network on data')
+parser = argparse.ArgumentParser(description='Generate a set of images showing the saliency of the input space')
+parser.add_argument('side_channels', metavar='N', type=str, nargs=1,
+                    help='Specify the side channel as none, true_value, current_goes, or hand_tailored.')
+parser.add_argument('aia_image_count', metavar='N', type=int, nargs=1,
+                    help='Specify the number of AIA images that were composited for the network.')
 parser.add_argument('network_model', metavar='N', type=str, nargs=1,
                     help='the full path to the network model that we want to evaluate. This will be a file with the .hdf5 extension.')
 args = parser.parse_args()
 
-# Specify the data
-#dataset_model = aia.AIA(side_channels=["hand_tailored"], aia_image_count=1, dependent_variable="flux delta")
-dataset_model = aia.AIA(side_channels=[""], aia_image_count=1, dependent_variable="flux delta")
-network_model = dataset_model.get_network_model(args.network_model[0])
+# Assign thearguments from the command line
+side_channels = args.side_channels[0]
+aia_image_count = args.aia_image_count[0]
+network_model_path = args.network_model[0]
 
-def compile_saliency_function(model):
+# We set the learning phase to "test" so that the network will not apply dropout
+K.set_learning_phase(0)
+
+# Specify the data. This currently defaults to models including the hand_tailored side channel
+dataset_model = aia.AIA(side_channels=[side_channels], aia_image_count=aia_image_count, dependent_variable="flux delta")
+network_model = dataset_model.get_network_model(network_model_path)
+
+# Compile the function that generates the gradients for input images based on the network
+def compile_saliency_function(model, grad_input_index=0):
     """
     Compiles a function to compute the saliency maps and predicted classes
     for a given minibatch of input images.
+    @param model {Keras Model} The model loaded from a hdf5 format file.
+    @param grad_input_index {int} The input component for which we are interested in the gradient.
+        The first indexed items will be the AIA images, followed by the side channel information.
     """
-    inp1 = model.layers[0].input
-    #inp2 = model.get_layer("Side_Channel").input
+    inp = model.input
     output = model.layers[-1].output
     loss = output[0]
-    grads = K.gradients(loss, inp1)[0]
-    grads /= (K.sqrt(K.mean(K.square(grads))) + 1e-5)
-    iterate = K.function([inp1, K.learning_phase()], [loss, grads])
+    grads = K.gradients(loss, inp)
+    #grads[0] /= (K.sqrt(K.mean(K.square(grads[0]))) + 1e-5) # regularize the gradients. Important if doing gradient updating to the inputs
+    iterate = K.function(inp, [loss, grads[grad_input_index]])
     return iterate
 
-saliency_function =  compile_saliency_function(network_model)
+def write_images(grads_value, image_index):
+    """Write out the attention images to disc
+    @param grads_value {tensor} The gradient tensor for the image.
+    @param image_index {int} The index of the image we are wanting
+        to print gradients for.
+    """    
+    for layer_idx in range(0,8):
+        layer = grads_value[image_index].reshape(1,8,1024,1024)[0][layer_idx]
+        most = float("-Inf")
+        least = float("Inf")
+        for idx in range(0, 1024):
+            for idx2 in range(0, 1024):
+                most = max(layer[idx][idx2], most)
+                least = min(layer[idx][idx2], least)
+        most = float(most)
+        least = float(least)
+        print "Layer " + str(layer_idx) + " largest gradient: " + str(most) + " smallest gradient: " + str(least)
+        for idx in range(0, 1024):
+            for idx2 in range(0, 1024):
+                layer[idx][idx2] = 255.0 * (layer[idx][idx2] - least)/(most - least)
 
+        imsave('gradient_image' + str(image_index) + "_layer_" + str(layer_idx) + '.png', layer)
+
+
+# Get the validation data we are testing this script on, then select the first records
 dataset = dataset_model.get_validation_data()
 x_inputs = dataset[0]
-single_point =  x_inputs[0][0].reshape(1, 1024, 1024, 8)
 
-loss_value, grads_value = saliency_function([single_point, 0])
+# Add the first image to the inputs
+query_input =  [x_inputs[0][0].reshape(1, 1024, 1024, 8)]
 
-layer = grads_value.reshape(1,8,1024,1024)[0][0]
-most = float("-Inf")
-least = float("Inf")
-print layer.shape
-for idx in range(0, 1024):
-    for idx2 in range(0, 1024):
-        most = max(layer[idx][idx2], most)
-        least = min(layer[idx][idx2], least)
-most = float(most)
-least = float(least)
-for idx in range(0, 1024):
-    for idx2 in range(0, 1024):
-        layer[idx][idx2] = 255.0 * (layer[idx][idx2] - least)/(most - least)
+# Append all the images experienced by the network
+if aia_image_count > 1:
+    for i in range(1, aia_image_count):
+        query_input.append(x_inputs[i][0].reshape(1, 1024, 1024, 8))
 
-imsave('gradient.png', layer)
+# Append the side channel data. This will currently only append one side channel.
+if side_channels == "hand_tailored":
+    query_input.append(x_inputs[aia_image_count][0].reshape(1,25))
+elif len(side_channels) > 0:
+    query_input.append(x_inputs[aia_image_count][0].reshape(1,1))
+
+# Write the image output for each of the channels of the AIA images
+for image_index in range(0, aia_image_count):
+    # Compile the saliency function for the input image
+    saliency_function =  compile_saliency_function(network_model, grad_input_index=image_index)
+    loss_value, grads_value = saliency_function(query_input)
+    write_images(grads_value, image_index)


### PR DESCRIPTION
This pull request adds a script for printing the gradients of the output with respect to changes in the input. The command below will load a network that was trained with the hand_tailored side information and 1 input image, then write our 8 images rendering the gradient at each pixel location. The idea behind this is to find what are the most important or salient components of the input image. This script could be improved once we have networks that learn something about the spatial structure. All my networks are currently only paying attention to the side channel information.

>  python science/attention.py hand_tailored 1 /home/smcgregor/projects/solar-forecast/network_models/xray_flux_forecast/fdl4/trained_models/20170812-010115/epochs/weights.70-0.00.hdf5