### PR TITLE
added multi-process support

### DIFF
--- a/dataset_models/dataset.py
+++ b/dataset_models/dataset.py
@@ -45,12 +45,28 @@ class Dataset(object):
         """
         raise NotImplementedError
 
-    def training_generator(self):
+    def get_training_generator(self):
         """
         Generate samples for training by selecting a random subsample of
         files located in the training directory. The training data will
         then be collected with the additional timesteps of images
         and side channel information.
+        """
+        raise NotImplementedError
+
+    def get_training_generator_multiprocess(self):
+        """
+        Return data for training in a threadsafe manner. To
+        instantiate this method you should generally
+        utilize the Keras Sequence class.
+        """
+        raise NotImplementedError
+
+    def get_validation_generator_multiprocess(self):
+        """
+        Return data for validation in a threadsafe manner. To
+        instantiate this method you should generally
+        utilize the Keras Sequence class.
         """
         raise NotImplementedError
 

--- a/dataset_models/sdo/aia.py
+++ b/dataset_models/sdo/aia.py
@@ -4,6 +4,7 @@ from datetime import timedelta, datetime
 import random
 import math
 import dataset_models.dataset
+from dataset_models.sequencer import GeneratorSequence
 from operator import div, sub
 import feather
 
@@ -102,7 +103,7 @@ class AIA(dataset_models.dataset.Dataset):
             data_y = []
             data_x = []
             for f in self.validation_files:
-                sample = self._get_x_data(f, aia_image_count=self.aia_image_count, training=False)
+                sample = self._get_x_data(f, training=False)
                 self._sample_append(data_x, sample)
                 data_y.append(self._get_y(f))
             yield self._finalize_dataset(data_x, data_y)
@@ -122,7 +123,7 @@ class AIA(dataset_models.dataset.Dataset):
         while 1:
             f = files[i]
             i += 1
-            sample = self._get_x_data(f, aia_image_count=self.aia_image_count, training=True)
+            sample = self._get_x_data(f, training=True)
             self._sample_append(data_x, sample)
             data_y.append(self._get_y(f))
 
@@ -134,6 +135,18 @@ class AIA(dataset_models.dataset.Dataset):
                 yield self._finalize_dataset(data_x, data_y)
                 data_x = []
                 data_y = []
+
+    def get_training_generator_multiprocess(self):
+        """
+        Generate sets of training data in a threadsafe manner.
+        """
+        return GeneratorSequence(
+            dataset_model_class=AIA,
+            batch_size=self.samples_per_step,
+            dataset_model_params={"side_channels": self.side_channels,
+                "aia_image_count": self.aia_image_count,
+                "dependent_variable": self.dependent_variable
+            })
 
     def get_network_model(self, network_model_path):
         """Load a network model from file.
@@ -171,7 +184,7 @@ class AIA(dataset_models.dataset.Dataset):
             for filename in file_names:
                 data_x = []
                 data_y = []
-                sample = self._get_x_data(filename, aia_image_count=self.aia_image_count, training=training)
+                sample = self._get_x_data(filename, training=training)
                 self._sample_append(data_x, sample)
                 data_y.append(-999999999999.0)
                 prediction = model.predict(self._finalize_dataset(data_x, data_y)[0], verbose=0)
@@ -487,11 +500,10 @@ class AIA(dataset_models.dataset.Dataset):
         if "hand_tailored" in self.side_channels:
             return np.array(self._get_hand_tailored_side_channel_data(filename))
 
-    def _get_x_data(self, filename, aia_image_count=2, training=None):
+    def _get_x_data(self, filename, training=None):
         """
         Get the list of data associated with the sample filename.
         @param filename {string} The name of the file which we are currently sampling.
-        @param aia_image_count {int} The total number of timestep images to be composited.
         @param current_data {list} The data that we will append to.
         @param training {bool} Indicates whether we are currently training or testing.
            This will determine where we look for x-files.
@@ -501,7 +513,7 @@ class AIA(dataset_models.dataset.Dataset):
             directory = self.training_directory
         else:
             directory = self.validation_directory
-        for index in range(0, aia_image_count):
+        for index in range(0, self.aia_image_count):
             current_data.append(self._get_aia_image(filename, directory, previous=index))
         if self.side_channels:
             data_x_side_channel_sample = self._get_side_channel_data(filename)

--- a/dataset_models/sequencer.py
+++ b/dataset_models/sequencer.py
@@ -1,0 +1,58 @@
+import keras.utils.data_utils
+import random
+
+class GeneratorSequence(keras.utils.data_utils.Sequence):
+    """
+    The sequence class ensures the data returned to the training/validation processes is
+    in a reliable sequence and can be run on multiple processes. Without this class,
+    you will not be able to prepare multiple sets of data for the GPU in parallel.
+
+    WARNING: This sequencer presently shuffles the training data before every
+             batch. This means that sequential batches may contain the same
+             data. This should not be a problem for sufficiently large datasets,
+             but it could be a problem if your dataset is small.
+    """
+
+    def __init__(self, dataset_model_class=None, batch_size=-1,
+                 dataset_model_params={"side_channels": -1, "aia_image_count": -1, "dependent_variable": None}):
+        """Copy the current dataset model so it will sit in this separate
+        process. The separate process will then pass ready objects
+        between processes by pickling.
+        @param dataset_model {DatasetModel|None} a dataset model. Multiprocessing batches should
+        pass None into this parameter since the process will instantiate the object.
+        """
+        assert(dataset_model_class is not None)
+        assert(batch_size is not -1)
+        self.dataset_model_class = dataset_model_class
+        self.batch_size = batch_size
+        self.dataset_model = dataset_model_class(**dataset_model_params)
+        self.dataset_model_params = dataset_model_params
+
+    def __len__(self):
+        """@return the number of samples included in each batch"""
+        return self.batch_size
+
+    def __getitem__(self, batch_idx):
+        """Get a batch of samples. If the batch size will take the sampling
+        past the current list of files, then the files list will be
+        shuffled and the sampling will continue from the beginning.
+        """@
+        dataset_model = self.dataset_model
+        files = dataset_model.train_files
+        random.seed(batch_idx)
+        random.shuffle(files)
+        data_x = []
+        data_y = []
+        for idx in range(0, self.batch_size):
+            file_index = self._get_file_index(batch_idx, idx, len(files))
+            f = files[file_index]
+            sample = dataset_model._get_x_data(f, training=True)
+            dataset_model._sample_append(data_x, sample)
+            data_y.append(dataset_model._get_y(f))
+        finalized = dataset_model._finalize_dataset(data_x, data_y)
+        return finalized
+
+    def _get_file_index(self, batch_idx, idx, file_count):
+        """Return the index of the current item that should be returned."""
+        file_index = (batch_idx * self.batch_size + idx) % file_count
+        return file_index

--- a/network_models/experiment.py
+++ b/network_models/experiment.py
@@ -78,14 +78,41 @@ def experiment(network_model, output_path, dataset_model=None, args=None, config
         os.makedirs(model_output_path)
     model_checkpoint = ModelCheckpoint(model_output_path)
 
-    history = network_model.fit_generator(dataset_model.get_training_generator(),
+    # Default to the simple generator unless the `training_multiprocess`
+    # flag is set within the config file
+    if "training_multiprocess" in config and config["training_multiprocess"]:
+        print("Training will run in **multiple** processes. Change your config if this is undesired.")
+        training_generator = dataset_model.get_training_generator_multiprocess()
+        use_multiprocessing = True
+    else:
+        print("Training will run in a **single** processes. Change your config if this is undesired.")
+        training_generator = dataset_model.get_training_generator()
+        use_multiprocessing = False
+
+    # Default to getting all the training data unless the
+    # `validation_generator` flag is set within the config file
+    if "validation_generator" in config and config["validation_generator"]:
+        validation_generator = dataset_model.get_validation_generator()
+    else:
+        print("All validation data will be loaded into memory. Change your config if this is undesired.")
+        validation_generator = dataset_model.get_validation_data()
+
+    # Workers specify the number of processes and/or threads executing
+    if "workers" in config:
+        workers = config["workers"]
+    else:
+        workers = 1
+    print("Running with %d workers" % workers)
+
+    history = network_model.fit_generator(training_generator,
                                        steps_per_epoch,
                                        max_queue_size=10,
                                        epochs=epochs,
-                                       validation_data=dataset_model.get_validation_generator(),
+                                       validation_data=validation_generator,
                                        callbacks=[tensorboard_callbacks, training_callbacks, model_checkpoint],
                                        validation_steps=dataset_model.get_validation_step_count(),
-                                       workers=1,
+                                       workers=workers,
+                                       use_multiprocessing=use_multiprocessing,
     )
 
     # Loss on the training set

--- a/network_models/experiment.py
+++ b/network_models/experiment.py
@@ -88,6 +88,10 @@ def experiment(network_model, output_path, dataset_model=None, args=None, config
         print("Training will run in a **single** processes. Change your config if this is undesired.")
         training_generator = dataset_model.get_training_generator()
         use_multiprocessing = False
+        if "workers" in config and config["workers"] > 1:
+            print("!!! Multi-threading is not currently supported.")
+            print("Please set the number of workers to 1 or use multi-process")
+            exit()
 
     # Default to getting all the training data unless the
     # `validation_generator` flag is set within the config file

--- a/network_models/xray_flux_forecast/starting_point/config.yml
+++ b/network_models/xray_flux_forecast/starting_point/config.yml
@@ -3,3 +3,6 @@ steps_per_epoch: 100
 samples_per_step: 20
 epochs: 100
 loss: mean_squared_error
+training_multiprocess: True
+validation_generator: True
+workers: 2


### PR DESCRIPTION
This pull request adds multiprocess support for preparing training data on multiple processor cores. I have not tested this on a GPU machine for bottlenecks, so that could be an element of a pull request review.

You can turn turn on multiprocess training by adding these lines to the config.yml file in the training directory.

> training_multiprocess: True
> validation_generator: True
> workers: 2

You can tune the number of workers for your hardware.

Issues: #29 
  