### PR TITLE
Added back "get_validation_data"

### DIFF
--- a/dataset_models/sdo/aia.py
+++ b/dataset_models/sdo/aia.py
@@ -111,6 +111,21 @@ class AIA(dataset_models.dataset.Dataset):
                 data_y.append(self._get_y(f))
             yield self._finalize_dataset(data_x, data_y)
 
+    def get_validation_data(self):
+        """
+        Load samples for validation dataset. This will load the entire validation dataset
+        into memory. If you have a very large validation dataset you should likely
+        refactor this to be a data generator that will stage the data into memory incrementally.
+        """
+        data_y = []
+        data_x = []
+        for f in self.validation_files:
+            sample = self._get_x_data(f, training=False)
+            self._sample_append(data_x, sample)
+            data_y.append(self._get_y(f))
+
+        return self._finalize_dataset(data_x, data_y)
+
     def get_training_generator(self):
         """
         Generate samples for training by selecting a random subsample of

--- a/dataset_models/sequencer.py
+++ b/dataset_models/sequencer.py
@@ -36,7 +36,7 @@ class GeneratorSequence(keras.utils.data_utils.Sequence):
         """Get a batch of samples. If the batch size will take the sampling
         past the current list of files, then the files list will be
         shuffled and the sampling will continue from the beginning.
-        """@
+        """
         dataset_model = self.dataset_model
         files = dataset_model.train_files
         random.seed(batch_idx)


### PR DESCRIPTION
- Removed a typo "@" in sequencer.py
- Added back the "get_validation_data" function in order to enable non-multiprocess validation because the multiprocess validation generator is misbehaving both when using single or multiprocess.